### PR TITLE
Set up envs

### DIFF
--- a/stravaStore/src/main/resources/application-dev.yml
+++ b/stravaStore/src/main/resources/application-dev.yml
@@ -1,0 +1,7 @@
+datasources:
+  default:
+    url: jdbc:mysql://localhost:3306/db
+    username: stravastore
+    password: stravastore
+    dialect: MYSQL
+    driverClassName: com.mysql.cj.jdbc.Driver

--- a/stravaStore/src/main/resources/application.yml
+++ b/stravaStore/src/main/resources/application.yml
@@ -4,14 +4,6 @@ micronaut:
   server:
     port: 10051
 
-datasources:
-  default:
-    url: jdbc:mysql://localhost:3306/db
-    username: stravastore
-    password: stravastore
-    dialect: MYSQL
-    driverClassName: com.mysql.cj.jdbc.Driver
-
 flyway:
   datasources:
     default:

--- a/stravaStore/src/test/resources/application-test.yml
+++ b/stravaStore/src/test/resources/application-test.yml
@@ -1,4 +1,3 @@
 datasources:
   default:
-    dialect: MYSQL
-    driverClassName: com.mysql.cj.jdbc.Driver
+    db-type: mysql


### PR DESCRIPTION
The issue was that application.yml was defining a URL, so the tests were using that one

The fix is to remove it from there, and add it to a `-dev` config file (for running locally)

And then the `-test` config correctly uses test-resources